### PR TITLE
Patch to provide Linux package & associated CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,11 +113,13 @@ jobs:
         uses: actions/download-artifact@v1
         with:
           name: OpConCLI_Windows.zip
+          path: ./
 
       - name: Download Linux Package
         uses: actions/download-artifact@v1
         with:
           name: OpConCLI_Linux.tar.gz
+          path: ./
 
       # Create a new release out of the Tag being pushed
       - name: Create Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,30 +44,47 @@ jobs:
           cp opcon-cli-dist/opconcli.exe OpConCLI_Windows/
           cp opcon-cli-dist/EncryptValue.exe OpConCLI_Windows/
           cp opcon-cli-dist/Connector.config OpConCLI_Windows/
-          
+
       # Zip the folder that contains all binaries and configuration to run on Windows (including Java)    
       - name: Zip Windows Folder
         uses: montudor/action-zip@v0.1.0
         with:
           args: zip -qq -r ./OpConCLI_Windows.zip ./OpConCLI_Windows
-      
-      # Upload the opconcli.exe binary file as artifact
-      - uses: actions/upload-artifact@v1
-        with:
-          name: opconcli.exe
-          path: opcon-cli-dist/opconcli.exe
-      
-      # Upload the ecryptvalue.exe binary file as artifact
-      - uses: actions/upload-artifact@v1
-        with:
-          name: EncryptValue.exe
-          path: opcon-cli-dist/EncryptValue.exe
 
-      # Upload the OpConCLI.zip file as artifact
+      # Upload the OpConCLI_Windows.zip file as artifact
       - uses: actions/upload-artifact@v1
         with:
           name: OpConCLI_Windows.zip
           path: ./OpConCLI_Windows.zip
+      
+      # Download the latest GA OpenJDK JRE 11 from AdoptOpenJDK for Linux x64
+      - name: Get Java 11 JRE for Windows x64
+        run: curl -L "https://api.adoptopenjdk.net/v3/binary/latest/11/ga/linux/x64/jre/hotspot/normal/adoptopenjdk" --output java.zip
+
+      # Extract Linux JRE
+      - name: Extract JRE into Java
+        run: 7z x java.zip -o./opcon-cli-dist/
+      
+      # Prepare the Linux distribution folder for Zip
+      - name: Create Windows Folder
+        run: |
+          mkdir OpConCLI_Linux
+          mv opcon-cli-dist/jdk-* OpConCLI_Linux/java
+          cp opcon-cli-dist/opconcli OpConCLI_Linux/
+          cp opcon-cli-dist/EncryptValue OpConCLI_Linux/
+          cp opcon-cli-dist/Connector.config OpConCLI_Linux/
+      
+      # Zip the folder that contains all binaries and configuration to run on Linux (including Java)    
+      - name: Zip Windows Folder
+        uses: montudor/action-zip@v0.1.0
+        with:
+          args: zip -qq -r ./OpConCLI_Linux.zip ./OpConCLI_Linux
+
+      # Upload the OpConCLI_Linux.zip file as artifact
+      - uses: actions/upload-artifact@v1
+        with:
+          name: OpConCLI_Linux.zip
+          path: ./OpConCLI_Linux.zip
           
      # Release - only ran when pushing new Tag starting with 'v'
      # Create a new release out of the Tag being pushed
@@ -95,4 +112,18 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: OpConCLI_Windows.zip
           asset_name: OpConCLI_Windows.zip
+          asset_content_type: application/zip
+
+      # Release - only ran when pushing new Tag starting with 'v'
+      # Upload the Linux Zip distribution to the newly created Release
+      - name: Upload Release Asset
+        if: startsWith(github.ref, 'refs/tags/v')
+        id: upload_release_asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: OpConCLI_Linux.zip
+          asset_name: OpConCLI_Linux.zip
           asset_content_type: application/zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,12 @@ jobs:
       # Build the maven project, output into ./opcon-cli-dist/
       - name: Build
         run: mvn clean package
-      
+
+        
+####################################
+# Create Windows Distribution File #
+####################################        
+
       # Download the latest GA OpenJDK JRE 11 from AdoptOpenJDK for Windows x64
       - name: Get Java 11 JRE for Windows x64
         run: curl -L "https://api.adoptopenjdk.net/v3/binary/latest/11/ga/windows/x64/jre/hotspot/normal/adoptopenjdk" --output java.zip
@@ -56,7 +61,11 @@ jobs:
         with:
           name: OpConCLI_Windows.zip
           path: ./OpConCLI_Windows.zip
-      
+
+##################################
+# Create Linux Distribution File #
+################################## 
+          
       # Download the latest GA OpenJDK JRE 11 from AdoptOpenJDK for Linux x64
       - name: Get Java 11 JRE for Windows x64
         run: curl -L "https://api.adoptopenjdk.net/v3/binary/latest/11/ga/linux/x64/jre/hotspot/normal/adoptopenjdk" --output java.tar.gz
@@ -88,6 +97,11 @@ jobs:
           name: OpConCLI_Linux.tar.gz
           path: ./OpConCLI_Linux.tar.gz
           
+
+#########################
+# RELEASE | TAG CREATED #
+#########################
+
      # Release - only ran when pushing new Tag starting with 'v'
      # Create a new release out of the Tag being pushed
       - name: Create Release
@@ -101,31 +115,13 @@ jobs:
           release_name: Release ${{ github.ref }}
           draft: true
           prerelease: false
-      
-      # Release - only ran when pushing new Tag starting with 'v'
-      # Upload the Windows Zip distribution to the newly created Release
-      - name: Upload Release Asset
-        if: startsWith(github.ref, 'refs/tags/v')
-        id: upload_release_asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: OpConCLI_Windows.zip
-          asset_name: OpConCLI_Windows.zip
-          asset_content_type: application/zip
 
       # Release - only ran when pushing new Tag starting with 'v'
-      # Upload the Linux Zip distribution to the newly created Release
-      - name: Upload Release Asset
+      # Upload the Windows Zip & Linux Tar distribution files to the newly created Release
+      - name: Upload Release Assets
         if: startsWith(github.ref, 'refs/tags/v')
         id: upload_release_asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: AButler/upload-release-assets@v2.0
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: OpConCLI_Linux.tar.gz
-          asset_name: OpConCLI_Linux.tar.gz
-          asset_content_type: application/tar.gz
+          files: 'OpConCLI_Windows.zip;OpConCLI_Linux.tar.gz'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,4 +141,4 @@ jobs:
         with:
           files: 'OpConCLI_Windows.zip;OpConCLI_Linux.tar.gz'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          release-tag: ${{ github.ref }}
+          release-tag: ${GITHUB_REF:10}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,7 @@ jobs:
   Job_Release:
     name: Release
     needs: job_Package
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     
     steps:
@@ -140,3 +141,4 @@ jobs:
         with:
           files: 'OpConCLI_Windows.zip;OpConCLI_Linux.tar.gz'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          release-tag: ${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
         with:
           tag_name: ${{ github.ref }}
           release_name: Release ${{ github.ref }}
-          draft: true
+          draft: false
           prerelease: false
 
       # Release - only ran when pushing new Tag starting with 'v'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,9 +102,10 @@ jobs:
   # RELEASE | TAG CREATED #
   #########################
   Job_Release:
+    # Release - only ran when pushing new Tag starting with 'v'
+    if: startsWith(github.ref, 'refs/tags/v')
     name: Release
     needs: job_Package
-    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     
     steps:
@@ -118,10 +119,8 @@ jobs:
         with:
           name: OpConCLI_Linux.tar.gz
 
-      # Release - only ran when pushing new Tag starting with 'v'
       # Create a new release out of the Tag being pushed
       - name: Create Release
-        if: startsWith(github.ref, 'refs/tags/v')
         id: create_release
         uses: actions/create-release@latest
         env:
@@ -132,13 +131,26 @@ jobs:
           draft: false
           prerelease: false
 
-      # Release - only ran when pushing new Tag starting with 'v'
-      # Upload the Windows Zip & Linux Tar distribution files to the newly created Release
-      - name: Upload Release Assets
-        if: startsWith(github.ref, 'refs/tags/v')
-        id: upload_release_asset
-        uses: AButler/upload-release-assets@v2.0
+      # Upload the Windows Zip distribution to the newly created Release
+      - name: Upload Windows Release Asset
+        id: upload_release_asset_win
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          files: 'OpConCLI_Windows.zip;OpConCLI_Linux.tar.gz'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          release-tag: ${GITHUB_REF:10}
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: OpConCLI_Windows.zip
+          asset_name: OpConCLI_Windows.zip
+          asset_content_type: application/zip
+
+      # Upload the Windows Zip distribution to the newly created Release
+      - name: Upload Linux Release Asset
+        id: upload_release_asset_linux
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: OpConCLI_Linux.tar.gz
+          asset_name: OpConCLI_Linux.tar.gz
+          asset_content_type: application/gzip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     tags:
       - 'v*'
 
-name: CI
+name: OpCon CLI
 
 jobs:
   build:
@@ -28,7 +28,7 @@ jobs:
       - name: Build
         run: mvn clean package
 
-        
+
 ####################################
 # Create Windows Distribution File #
 ####################################        
@@ -67,17 +67,15 @@ jobs:
 ################################## 
           
       # Download the latest GA OpenJDK JRE 11 from AdoptOpenJDK for Linux x64
-      - name: Get Java 11 JRE for Windows x64
+      - name: Get Java 11 JRE for Linux x64
         run: curl -L "https://api.adoptopenjdk.net/v3/binary/latest/11/ga/linux/x64/jre/hotspot/normal/adoptopenjdk" --output java.tar.gz
 
       # Extract Linux JRE
       - name: Extract JRE into Java
-        run: |
-          mkdir ./opcon-cli-dist/
-          tar xvzf java.tar.gz -C ./opcon-cli-dist
+        run: tar xvzf java.tar.gz -C ./opcon-cli-dist
       
       # Prepare the Linux distribution folder for Zip
-      - name: Create Windows Folder
+      - name: Create Linux Folder
         run: |
           mkdir OpConCLI_Linux
           mv opcon-cli-dist/jdk-* OpConCLI_Linux/java

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,13 @@ on:
 name: OpCon CLI
 
 jobs:
-  build:
+
+  ###########
+  # PACKAGE #
+  ###########
+  Job_Package:
     runs-on: ubuntu-latest
-    name: CI on Java 11
+    name: Package
     
     steps:
       # Checkout the code
@@ -28,10 +32,9 @@ jobs:
       - name: Build
         run: mvn clean package
 
-
-####################################
-# Create Windows Distribution File #
-####################################        
+      ####################################
+      # Create Windows Distribution File #
+      ####################################        
 
       # Download the latest GA OpenJDK JRE 11 from AdoptOpenJDK for Windows x64
       - name: Get Java 11 JRE for Windows x64
@@ -62,9 +65,9 @@ jobs:
           name: OpConCLI_Windows.zip
           path: ./OpConCLI_Windows.zip
 
-##################################
-# Create Linux Distribution File #
-################################## 
+      ##################################
+      # Create Linux Distribution File #
+      ################################## 
           
       # Download the latest GA OpenJDK JRE 11 from AdoptOpenJDK for Linux x64
       - name: Get Java 11 JRE for Linux x64
@@ -95,13 +98,27 @@ jobs:
           name: OpConCLI_Linux.tar.gz
           path: ./OpConCLI_Linux.tar.gz
           
+  #########################
+  # RELEASE | TAG CREATED #
+  #########################
+  Job_Release:
+    name: Release
+    needs: job_Package
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Download Windows Package
+        uses: actions/download-artifact@v1
+        with:
+          name: OpConCLI_Windows.zip
 
-#########################
-# RELEASE | TAG CREATED #
-#########################
+      - name: Download Linux Package
+        uses: actions/download-artifact@v1
+        with:
+          name: OpConCLI_Linux.tar.gz
 
-     # Release - only ran when pushing new Tag starting with 'v'
-     # Create a new release out of the Tag being pushed
+      # Release - only ran when pushing new Tag starting with 'v'
+      # Create a new release out of the Tag being pushed
       - name: Create Release
         if: startsWith(github.ref, 'refs/tags/v')
         id: create_release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,32 +59,34 @@ jobs:
       
       # Download the latest GA OpenJDK JRE 11 from AdoptOpenJDK for Linux x64
       - name: Get Java 11 JRE for Windows x64
-        run: curl -L "https://api.adoptopenjdk.net/v3/binary/latest/11/ga/linux/x64/jre/hotspot/normal/adoptopenjdk" --output java.zip
+        run: curl -L "https://api.adoptopenjdk.net/v3/binary/latest/11/ga/linux/x64/jre/hotspot/normal/adoptopenjdk" --output java.tar.gz
 
       # Extract Linux JRE
       - name: Extract JRE into Java
-        run: 7z x java.zip -o./opcon-cli-dist/
+        run: |
+          mkdir ./opcon-cli-dist/
+          tar xvzf java.tar.gz -C ./opcon-cli-dist
       
       # Prepare the Linux distribution folder for Zip
       - name: Create Windows Folder
         run: |
           mkdir OpConCLI_Linux
           mv opcon-cli-dist/jdk-* OpConCLI_Linux/java
+          chmod a+x opcon-cli-dist/opconcli
           cp opcon-cli-dist/opconcli OpConCLI_Linux/
+          chmod a+x opcon-cli-dist/EncryptValue
           cp opcon-cli-dist/EncryptValue OpConCLI_Linux/
           cp opcon-cli-dist/Connector.config OpConCLI_Linux/
       
-      # Zip the folder that contains all binaries and configuration to run on Linux (including Java)    
-      - name: Zip Windows Folder
-        uses: montudor/action-zip@v0.1.0
-        with:
-          args: zip -qq -r ./OpConCLI_Linux.zip ./OpConCLI_Linux
+      # tar.gz the folder that contains all binaries and configuration to run on Linux (including Java)    
+      - name: Zip Linux Folder
+        run: tar -cvzf ./OpConCLI_Linux.tar.gz ./OpConCLI_Linux
 
-      # Upload the OpConCLI_Linux.zip file as artifact
+      # Upload the OpConCLI_Linux.tar.gz file as artifact
       - uses: actions/upload-artifact@v1
         with:
-          name: OpConCLI_Linux.zip
-          path: ./OpConCLI_Linux.zip
+          name: OpConCLI_Linux.tar.gz
+          path: ./OpConCLI_Linux.tar.gz
           
      # Release - only ran when pushing new Tag starting with 'v'
      # Create a new release out of the Tag being pushed
@@ -124,6 +126,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: OpConCLI_Linux.zip
-          asset_name: OpConCLI_Linux.zip
-          asset_content_type: application/zip
+          asset_path: OpConCLI_Linux.tar.gz
+          asset_name: OpConCLI_Linux.tar.gz
+          asset_content_type: application/tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ opcon-cli-dist/
 .project
 .settings/
 target/
+log/

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ After download, extract the zip file to the location you'd like to install the c
 ### Linux Instructions
 [FILES WILL SOON BE AVAILABLE]
 
-Download OpConCLI_Linux.tar file from the desired [release available here](https://github.com/SMATechnologies/opcon-cli-java/releases).
+Download OpConCLI_Linux.tar.gz file from the desired [release available here](https://github.com/SMATechnologies/opcon-cli-java/releases).
 
 # Disclaimer
 No Support and No Warranty are provided by SMA Technologies for this project and related material. The use of this project's files is on your own risk.

--- a/README.md
+++ b/README.md
@@ -46,8 +46,6 @@ Download OpConCLI_Windows.zip file from the desired [release available here](htt
 After download, extract the zip file to the location you'd like to install the command line utility. Once unzipped, everything needed should be located under the root folder of that directory.
 
 ### Linux Instructions
-[FILES WILL SOON BE AVAILABLE]
-
 Download OpConCLI_Linux.tar.gz file from the desired [release available here](https://github.com/SMATechnologies/opcon-cli-java/releases).
 
 # Disclaimer

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The utility is available for both Windows and Linux.
 
 See [documentation](/documentation/opcon-cli.md) for the complete documentation.
 
-It consists of a single program **opconcli.exe** for Windows and **opconcli.sh** for Linux.
+It consists of a single program **opconcli.exe** for Windows and **opconcli** for Linux.
 
 ## Supported Tasks
 The opconcli program provides the following tasks:

--- a/documentation/opcon-cli.md
+++ b/documentation/opcon-cli.md
@@ -68,6 +68,8 @@ On Windows, example on how to encrypt the value "abcdefg":
 EncryptValue -v abcdefg
 ```
 
+## Exit Codes
+The `opconcli` exits `0` when the performed request succeeds. Otherwise `opconcli` exits `1` on failure.
 
 ## Command Line Arguments
 The opconcli program requires arguments to be given to function. It uses the principle of Tasks, where each task perform an action or a combinaison of actions against OpCon.

--- a/documentation/opcon-cli.md
+++ b/documentation/opcon-cli.md
@@ -3,7 +3,7 @@
 OpCon CLI is a command line utility for Windows & Linux that uses the OpCon REST-API to interact with OpCon. Provides functions to manage machines, 
 machine groups, jobs, properties, thresholds and schedules...
 
-It consists of a single program **opconcli.exe** for Windows and **opconcli.sh** for Linux.
+It consists of a single program **opconcli.exe** for Windows and **opconcli** for Linux.
 
 ## Installation
 
@@ -19,18 +19,16 @@ Download OpConCLI_Windows.zip file from the desired [release available here](htt
 After download, extract the zip file to the location you'd like to install the command line utility. Once unzipped, everything needed should be located under the root folder of that directory.
 
 ### Linux Instructions
-[FILES WILL SOON BE AVAILABLE]
+Download OpConCLI_Linux.tar.gz file from the desired [release available here](https://github.com/SMATechnologies/opcon-cli-java/releases).
 
-Download OpConCLI_Linux.tar file from the desired [release available here](https://github.com/SMATechnologies/opcon-cli-java/releases).
-
-After download, extract the zip file to the location you'd like to install the command line utility. Once unzipped, everything needed should be located under the root folder of that directory.
+After download, extract the tar.gz file to the location you'd like to install the command line utility. Once extracted, everything needed should be located under the root folder of that directory.
 
 ## Configuration
 The OpConCLI utility uses a configuration file **Connector.config** that contains the OpCon System connection information.
 
 The header name of the OpCon System connection information is used by the **-o** command argument to retrieve the connection information for the required system. This allows the utility to submit requests to multiple OpCon systems from a single installation avoiding user to pass credentials every single time.
 
-The **USER** and **PASSWORD** information should be encrypted using the **EncryptValue.exe** program for Windows or **EncryptValue.sh** shell for Linux (included in the zip/tar file). The encryption tool provides basic encryption capabilities to prevent clear text.
+The **USER** and **PASSWORD** information should be encrypted using the **EncryptValue.exe** program for Windows or **EncryptValue** shell script for Linux (included in the zip files). The encryption tool provides basic encryption capabilities to prevent clear text.
 
 **Connector.config** file example:
 ```
@@ -67,8 +65,9 @@ Supports a -v argument and displays the encrypted value
 
 On Windows, example on how to encrypt the value "abcdefg":
 ```
-EncryptValue.exe -v abcdefg
+EncryptValue -v abcdefg
 ```
+
 
 ## Command Line Arguments
 The opconcli program requires arguments to be given to function. It uses the principle of Tasks, where each task perform an action or a combinaison of actions against OpCon.

--- a/pom.xml
+++ b/pom.xml
@@ -216,6 +216,8 @@
 					<configuration>
 		  				<target>
               				<copy file="${project.basedir}/src/main/resources/Connector.config" todir="${release.dir}"/>
+							<copy file="${project.basedir}/src/main/resources/opconcli" todir="${release.dir}"/>
+							<copy file="${project.basedir}/src/main/resources/EncryptValue" todir="${release.dir}"/>
 						</target>
 					</configuration>
 					<goals>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.smatechnologies</groupId>
   <artifactId>opcon.command.api</artifactId>
-  <version>1.0.2-SNAPSHOT</version>
+  <version>1.1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>opcon.command.api</name>

--- a/src/main/resources/EncryptValue
+++ b/src/main/resources/EncryptValue
@@ -1,0 +1,5 @@
+#!/bin/bash
+SCRIPT_DIR=$(dirname "$0")
+cd $SCRIPT_DIR
+JAVA="./java/bin/java"
+exec $JAVA -cp opcon.command.api.jar com.smatechnologies.opcon.command.api.EncryptValue "$@"

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -3,7 +3,7 @@
 <configuration>
     <property name="logback.logfile.name" value="${logback.logfile.name:-cmdline}" />
     <property name="logback.logfile" value="${logback.logfile:-TRUE}" />
-    <property name="logback.pattern.light" value="[%d{HH:mm:ss}] [%-5p] [%class{0}.%M] %msg %ex%n" />
+    <property name="logback.pattern.light" value="[%d{HH:mm:ss}] [%-5p] %msg %ex%n" />
     <property name="logback.pattern.full" value="[%d{yy-MM-dd HH:mm:ss.SSS}] [%-5p] (%-27c{0} %3L\\) %msg %ex{full}%n" />
 
     <property name="logback.path" value="${logback.path:-log}" />

--- a/src/main/resources/opconcli
+++ b/src/main/resources/opconcli
@@ -1,0 +1,5 @@
+#!/bin/bash
+SCRIPT_DIR=$(dirname "$0")
+cd $SCRIPT_DIR
+JAVA="./java/bin/java"
+exec $JAVA -cp opcon.command.api.jar com.smatechnologies.opcon.command.api.OpConCli "$@"


### PR DESCRIPTION
Provide support Linux package of OpCon CLI (closes #4)

Includes shell scripts to support (opconcli & EncryptValue) to run on Linux.

Includes the CI configuration update to:
- Publish Linux artifacts on pushes
- Support Creation of Release with Artifacts on Tag

Updated logging to remove the class name in light mode.